### PR TITLE
Rename App

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Interview-Nest",
+  "name": "interview-nest",
   "private": true,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
# Package Name Fix

As `package.json` requires name in all small case separated by dashes (-) modified that way.